### PR TITLE
Fixed 5 bugs 

### DIFF
--- a/stack.hpp
+++ b/stack.hpp
@@ -7,6 +7,10 @@ class Stack {
 public:
     Stack(std::size_t capacity): storage_(new T[capacity]), capacity_(capacity) {}
 
+    ~Stack() {
+        delete[] storage_;
+    }
+
     inline std::size_t capacity() const {
         return capacity_;
     }

--- a/stack.hpp
+++ b/stack.hpp
@@ -26,7 +26,7 @@ public:
     }
 
     T pop() {
-        if (position_ < 0) throw std::out_of_range("Stack is empty");
+        if (position_ <= 0) throw std::out_of_range("Stack is empty");
         return std::move(storage_[--position_]);
     }
 

--- a/stack.hpp
+++ b/stack.hpp
@@ -16,12 +16,12 @@ public:
     }
 
     void push(const T& element) {
-        if (position_ > capacity_) throw std::out_of_range("Not enough capacity");
+        if (position_ >= capacity_) throw std::out_of_range("Not enough capacity");
         storage_[position_++] = element;
     }
 
     void push(T&& element) {
-        if (position_ > capacity_) throw std::out_of_range("Not enough capacity");
+        if (position_ >= capacity_) throw std::out_of_range("Not enough capacity");
         storage_[position_++] = std::move(element);
     }
 

--- a/stack.hpp
+++ b/stack.hpp
@@ -27,7 +27,7 @@ public:
 
     T pop() {
         if (position_ < 0) throw std::out_of_range("Stack is empty");
-        return std::move(storage_[position_--]);
+        return std::move(storage_[--position_]);
     }
 
 private:


### PR DESCRIPTION
**Fixed invalid index on pop()**:
The index point to the position after the last element, so we need to decrement it before we can use it to retrieve the item.

**Fixed storage overflow on push() method**:
In both methods push() we need to check if the index is bigger or equal the capacity, otherwise we will overflow the storage.

**Fixed storage underflow on pop() method**:
If the position index is 0, the stack is empty, so we need to check <= 0 and not < 0!

**Fixed memory leak**:
Delete the storage allocated on the heap at destruction of the stack.